### PR TITLE
use irc crate for more robust compliance with the irc specification, as well as new features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,16 +24,317 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cxx"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.14",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.14",
+]
+
+[[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.14",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -36,13 +346,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "irc"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5510c4c4631e53c57d6b05c44ab8447d1db6beef28fb9d12c4d6a46fad9dfcc"
+dependencies = [
+ "chrono",
+ "encoding",
+ "futures-util",
+ "irc-proto",
+ "log",
+ "native-tls",
+ "parking_lot 0.11.2",
+ "pin-project",
+ "serde",
+ "serde_derive",
+ "thiserror",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-stream",
+ "tokio-util",
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "irc-client"
 version = "0.1.0"
 dependencies = [
+ "futures",
+ "irc",
  "serde",
  "serde_derive",
  "serde_json",
  "tokio",
+ "toml 0.7.3",
+]
+
+[[package]]
+name = "irc-proto"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55fa0a52d825e59ba8aea5b7503890245aea000f77e68d9b1903f3491fa33643"
+dependencies = [
+ "bytes",
+ "encoding",
+ "thiserror",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -52,10 +462,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -77,6 +517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,8 +530,45 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi",
- "windows-sys",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -94,8 +577,69 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "openssl"
+version = "0.10.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.14",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -105,7 +649,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -116,9 +674,29 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -126,6 +704,18 @@ name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro2"
@@ -155,16 +745,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
+name = "security-framework"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -183,7 +834,7 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -198,12 +849,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -224,6 +893,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
@@ -231,6 +911,59 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.14",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -244,12 +977,12 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -260,7 +993,85 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.14",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -270,10 +1081,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "winapi"
@@ -292,10 +1175,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
 
 [[package]]
 name = "windows-sys"
@@ -303,7 +1219,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -312,13 +1237,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -328,10 +1268,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -340,10 +1292,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -352,13 +1316,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.10",
  "toml 0.5.11",
 ]
 
@@ -439,6 +439,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tokio",
+ "tokio-util 0.7.7",
  "toml 0.7.3",
 ]
 
@@ -452,7 +453,7 @@ dependencies = [
  "encoding",
  "thiserror",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -1032,6 +1033,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1087,26 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+futures = "0.3.28"
+irc = "0.15.0"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_derive = "1.0.160"
 serde_json = "1.0.95"
 tokio = { version = "1.27.0", features = ["macros", "full"] }
+toml = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ serde = { version = "1.0.160", features = ["derive"] }
 serde_derive = "1.0.160"
 serde_json = "1.0.95"
 tokio = { version = "1.27.0", features = ["macros", "full"] }
+tokio-util = { version = "0.7.7", features = ["codec"] }
 toml = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,9 @@ serde_json = "1.0.95"
 tokio = { version = "1.27.0", features = ["macros", "full"] }
 tokio-util = { version = "0.7.7", features = ["codec"] }
 toml = "0.7.3"
+[profile.release]
+opt-level = "z"
+debug=false
+lto = "fat"
+codegen-units = 1
+panic = "abort"

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,36 +17,43 @@ struct AppConfig {
 
 async fn read_config() -> AppConfig {
     if Path::new("config.toml").exists() {
+println!("found configuration file");
         let config_str = fs::read_to_string("config.toml").expect("Unable to read config.toml");
         toml::from_str(&config_str).expect("Unable to parse config.toml")
     } else {
         println!("configuration file not found!");
         println!("In the following prompts, you'll be asked to fill in the required information about yourself and your irc network, in order to connect to your server");
+        let mut use_tls = String::new();
         let mut nickname = String::new();
         let mut server = String::new();
-        let mut channels_str = String::new();
+let mut port=String::new();
+        let mut channels = String::new();
 
         println!("Type your nickname, then press enter: ");
         stdin().read_line(&mut nickname).unwrap();
         println!("Type the address of your irc network. This is the domain one connects to specifically with an irc client, for example `irc.libera.chat`: ");
         stdin().read_line(&mut server).unwrap();
+    println!("enter the port for {} (default: 6667):", &server);
+stdin().read_line(&mut port).unwrap();
+        println!("Use TLS? (y/n): ");
+        stdin().read_line(&mut use_tls).unwrap();
         println!("Optionally, type in a list of channels you want to be prejoined to on startup, comma sepparated");
-        stdin().read_line(&mut channels_str).unwrap();
-
+        stdin().read_line(&mut channels).unwrap();
         println!("configuration complete!");
-        let channels = channels_str
+        let channels = channels
             .trim()
             .split(',')
             .map(|channel| channel.trim().to_string())
             .collect();
-
+    let port = port.parse::<u16>().unwrap_or(6667);
+        let use_tls = use_tls.trim().to_lowercase() == "y";
         let config = AppConfig {
             nickname: nickname.trim().to_string(),
             username: None,
             realname: None,
             server: server.trim().to_string(),
-            port: None,
-            use_tls: None,
+            port: Some(port),
+            use_tls: Some(use_tls),
             channels,
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,124 +1,89 @@
-use std::io::BufRead;
+use futures::prelude::*;
+use irc::client::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::{fs, io::stdin, path::Path};
+use toml;
 
-use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, BufWriter};
-use tokio::net::TcpStream;
-use tokio::sync::mpsc::{channel, Receiver, Sender};
-
-use tokio::task;
-
-#[derive(Debug, Clone)]
-struct Server(String);
-#[derive(Debug, Clone)]
-struct Port(u16);
-#[derive(Debug, Clone)]
-struct Nickname(String);
-#[derive(Debug, Clone)]
-struct Channel(String);
-
-#[derive(Debug, Clone)]
-enum Message {
-    Raw(String),
-    Join(Channel),
-    Pong(String),
+#[derive(Debug, Deserialize, Serialize)]
+struct AppConfig {
+    nickname: String,
+    username: Option<String>,
+    realname: Option<String>,
+    server: String,
+    port: Option<u16>,
+    use_tls: Option<bool>,
+    channels: Vec<String>,
 }
 
-async fn read_input(tx: Sender<Message>) {
-    let stdin = tokio::io::stdin();
-    let mut stdin_reader = BufReader::new(stdin);
-    loop {
-        let mut buffer = String::new();
-        match stdin_reader.read_line(&mut buffer).await {
-            Ok(_) => {
-                let trimmed_buffer = buffer.trim();
-                let message = if trimmed_buffer.starts_with("JOIN ") {
-                    Message::Join(Channel(trimmed_buffer[5..].trim().to_string()))
-                } else {
-                    Message::Raw(trimmed_buffer.to_string())
-                };
-                tx.send(message).await.unwrap();
-            }
-            Err(_) => break,
-        }
-    }
-}
-async fn read_stream<R: AsyncBufRead + Unpin>(mut stream: R, tx: Sender<Message>) {
-    loop {
-        let mut buffer = String::new();
-        match stream.read_line(&mut buffer).await {
-            Ok(_) => {
-                println!("Received line from server: {}", buffer); // Add this line for logging
-                let trimmed_buffer = buffer.trim();
-                let message = if trimmed_buffer.starts_with("PING") {
-                    Message::Pong(trimmed_buffer[5..].trim().to_string())
-                } else {
-                    Message::Raw(trimmed_buffer.to_string())
-                };
-                tx.send(message).await.unwrap();
-            }
-            Err(_) => break,
-        }
+async fn read_config() -> AppConfig {
+    if Path::new("config.toml").exists() {
+        let config_str = fs::read_to_string("config.toml").expect("Unable to read config.toml");
+        toml::from_str(&config_str).expect("Unable to parse config.toml")
+    } else {
+        println!("configuration file not found!");
+        println!("In the following prompts, you'll be asked to fill in the required information about yourself and your irc network, in order to connect to your server");
+        let mut nickname = String::new();
+        let mut server = String::new();
+        let mut channels_str = String::new();
+
+        println!("Type your nickname, then press enter: ");
+        stdin().read_line(&mut nickname).unwrap();
+        println!("Type the address of your irc network. This is the domain one connects to specifically with an irc client, for example `irc.libera.chat`: ");
+        stdin().read_line(&mut server).unwrap();
+        println!("Optionally, type in a list of channels you want to be prejoined to on startup, comma sepparated");
+        stdin().read_line(&mut channels_str).unwrap();
+
+        println!("configuration complete!");
+        let channels = channels_str
+            .trim()
+            .split(',')
+            .map(|channel| channel.trim().to_string())
+            .collect();
+
+        let config = AppConfig {
+            nickname: nickname.trim().to_string(),
+            username: None,
+            realname: None,
+            server: server.trim().to_string(),
+            port: None,
+            use_tls: None,
+            channels,
+        };
+
+        let config_str = toml::to_string(&config).expect("Unable to serialize config");
+        fs::write("config.toml", config_str).expect("Unable to write config.toml");
+
+        config
     }
 }
 
-async fn write_stream<W: AsyncWrite + Unpin>(mut stream: W, mut rx: Receiver<Message>) {
-    while let Some(message) = rx.recv().await {
-        match message {
-            Message::Join(channel) => {
-                let join_message = format!("JOIN {}\r\n", channel.0);
-                println!("Sending join message: {}", join_message); // Add this line for logging
-                stream.write_all(join_message.as_bytes()).await.unwrap();
-            }
-            Message::Raw(raw_message) => {
-                let raw_message = format!("{}\r\n", raw_message);
-                println!("Sending raw message: {}", raw_message); // Add this line for logging
-                stream.write_all(raw_message.as_bytes()).await.unwrap();
-            }
-            Message::Pong(server) => {
-                let pong_message = format!("PONG {}\r\n", server);
-                println!("Sending pong message: {}", pong_message); // Add this line for logging
-                stream.write_all(pong_message.as_bytes()).await.unwrap();
-            }
-        }
-    }
-}
 #[tokio::main]
-async fn main() {
-    let (_tx_input, _rx_input) = channel::<Message>(32);
-    let (tx_stream, rx_stream) = channel::<Message>(32);
-    let tx_stream_read = tx_stream.clone();
-    let tx_stream_input = tx_stream.clone();
-    println!("Enter server address:");
-    let server = read_line();
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = read_config().await;
 
-    println!("Enter server port (default: 6667):");
-    let port = read_line().parse::<u16>().unwrap_or(6667);
+    let irc_config = Config {
+        nickname: Some(config.nickname),
+        username: config.username,
+        realname: config.realname,
+        server: Some(config.server),
+        port: config.port,
+        use_tls: config.use_tls,
+        channels: config.channels,
+        ..Config::default()
+    };
 
-    println!("Enter your nickname:");
-    let nickname = read_line();
+    let mut client = Client::from_config(irc_config).await?;
+    client.identify()?;
+    let mut stream = client.stream()?;
 
-    let stream = TcpStream::connect(format!("{}:{}", server, port))
-        .await
-        .unwrap();
-
-    let (stream_reader, mut stream_writer) = stream.into_split();
-    stream_writer
-        .write_all(format!("NICK {}\r\n", nickname).as_bytes())
-        .await
-        .unwrap();
-    stream_writer
-        .write_all(format!("USER {} 0 * :{}\r\n", nickname, nickname).as_bytes())
-        .await
-        .unwrap();
-    stream_writer.write_all(b"CAP REQ :sasl\r\n").await.unwrap();
-    let read_input_task = task::spawn(read_input(tx_stream_input));
-    let read_stream_task = task::spawn(read_stream(BufReader::new(stream_reader), tx_stream_read));
-    let write_stream_task = task::spawn(write_stream(BufWriter::new(stream_writer), rx_stream));
-    tokio::try_join!(read_input_task, read_stream_task, write_stream_task).unwrap();
-}
-fn read_line() -> String {
-    let mut input = String::new();
-    let stdin = std::io::stdin();
-    let mut stdin_lock = stdin.lock();
-    stdin_lock.read_line(&mut input).unwrap();
-    input.trim().to_string()
+    while let Some(message) = stream.next().await.transpose()? {
+        print!("{}", message);
+        match message.command {
+            Command::PRIVMSG(ref target, ref msg) => {
+                println!("{}: {}", target, msg);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,15 @@
 use futures::prelude::*;
 use irc::client::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::{fs, io::stdin, path::Path};
+use std::{
+    collections::HashSet,
+    fs,
+    io::stdin,
+    path::Path,
+    sync::{Arc, Mutex},
+};
+use tokio::sync::mpsc;
 use toml;
-
 #[derive(Debug, Deserialize, Serialize)]
 struct AppConfig {
     nickname: String,
@@ -17,7 +23,7 @@ struct AppConfig {
 
 async fn read_config() -> AppConfig {
     if Path::new("config.toml").exists() {
-println!("found configuration file");
+        println!("found configuration file");
         let config_str = fs::read_to_string("config.toml").expect("Unable to read config.toml");
         toml::from_str(&config_str).expect("Unable to parse config.toml")
     } else {
@@ -26,15 +32,15 @@ println!("found configuration file");
         let mut use_tls = String::new();
         let mut nickname = String::new();
         let mut server = String::new();
-let mut port=String::new();
+        let mut port = String::new();
         let mut channels = String::new();
 
         println!("Type your nickname, then press enter: ");
         stdin().read_line(&mut nickname).unwrap();
         println!("Type the address of your irc network. This is the domain one connects to specifically with an irc client, for example `irc.libera.chat`: ");
         stdin().read_line(&mut server).unwrap();
-    println!("enter the port for {} (default: 6667):", &server);
-stdin().read_line(&mut port).unwrap();
+        println!("enter the port for {} (default: 6667):", &server);
+        stdin().read_line(&mut port).unwrap();
         println!("Use TLS? (y/n): ");
         stdin().read_line(&mut use_tls).unwrap();
         println!("Optionally, type in a list of channels you want to be prejoined to on startup, comma sepparated");
@@ -45,7 +51,7 @@ stdin().read_line(&mut port).unwrap();
             .split(',')
             .map(|channel| channel.trim().to_string())
             .collect();
-    let port = port.parse::<u16>().unwrap_or(6667);
+        let port = port.parse::<u16>().unwrap_or(6667);
         let use_tls = use_tls.trim().to_lowercase() == "y";
         let config = AppConfig {
             nickname: nickname.trim().to_string(),
@@ -63,6 +69,46 @@ stdin().read_line(&mut port).unwrap();
         config
     }
 }
+#[derive(Debug)]
+enum UserCommand {
+    Join(String),
+    Msg(String),
+    Switch(String),
+    Unknown,
+}
+
+async fn parse_user_input(line: &str) -> UserCommand {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.is_empty() {
+        return UserCommand::Unknown;
+    }
+
+    match parts[0] {
+        "/join" if parts.len() > 1 => UserCommand::Join(parts[1].to_owned()),
+        "/msg" if parts.len() > 1 => {
+            let message = parts[1..].join(" ");
+            UserCommand::Msg(message)
+        }
+        "/switch" if parts.len() > 1 => UserCommand::Switch(parts[1].to_owned()),
+        _ => UserCommand::Unknown,
+    }
+}
+async fn handle_user_input(sender: mpsc::Sender<UserCommand>) {
+    use tokio::io::{stdin};
+    use tokio_util::codec::{FramedRead, LinesCodec};
+    let stdin = stdin();
+    let mut lines = FramedRead::new(stdin, LinesCodec::new());
+    while let Some(line) = lines.next().await {
+        if let Ok(input) = line {
+            let cmd = parse_user_input(&input).await;
+            println!("{:?}", cmd);
+            if let Err(_) = sender.send(cmd).await {
+                println!("error sending message");
+                break;
+            }
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -75,14 +121,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         server: Some(config.server),
         port: config.port,
         use_tls: config.use_tls,
-        channels: config.channels,
+        channels: config.channels.clone(),
         ..Config::default()
     };
 
     let mut client = Client::from_config(irc_config).await?;
     client.identify()?;
+    let (tx, mut rx) = mpsc::channel::<UserCommand>(32);
+    let joined_channels = Arc::new(Mutex::new(HashSet::new()));
+    let current_channel = Arc::new(Mutex::new(String::new()));
     let mut stream = client.stream()?;
-
+    for channel in &config.channels {
+        joined_channels.lock().unwrap().insert(channel.clone());
+        *current_channel.lock().unwrap() = channel.clone();
+        client.send_join(channel)?;
+    }
+    let _input_processor = tokio::spawn(handle_user_input(tx));
     while let Some(message) = stream.next().await.transpose()? {
         print!("{}", message);
         match message.command {
@@ -92,5 +146,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             _ => {}
         }
     }
+    let _server_messages_processor = tokio::spawn(async move {
+        while let Ok(cmd) = rx.try_recv() {
+            match cmd {
+                UserCommand::Join(channel) => {
+                    println!("joining channel {}", channel);
+                    joined_channels.lock().unwrap().insert(channel.clone());
+                    *current_channel.lock().unwrap() = channel.clone();
+                    client.send_join(&channel).unwrap();
+                }
+                UserCommand::Msg(message) => {
+                    let target = current_channel.lock().unwrap().clone();
+                    if !target.is_empty() {
+                        client.send_privmsg(&target, &message).unwrap();
+                    } else {
+                        println!("No channel currently selected.");
+                    }
+                }
+                UserCommand::Switch(channel) => {
+                    if joined_channels.lock().unwrap().contains(&channel) {
+                        *current_channel.lock().unwrap() = channel;
+                    } else {
+                        joined_channels.lock().unwrap().insert(channel.clone());
+                        *current_channel.lock().unwrap() = channel.clone();
+                        client.send_join(&channel).unwrap();
+                    }
+                }
+                UserCommand::Unknown => {
+                    println!("Unknown command or invalid usage.");
+                }
+            }
+        }
+    });
+    //    tokio::try_join!(input_processor, server_messages_processor)?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,9 @@ use std::{
     fs,
     io::stdin,
     path::Path,
-    sync::{Arc, Mutex},
+    sync::{mpsc,Arc, Mutex},
 };
-use tokio::sync::mpsc;
+//use tokio::sync::mpsc;
 
 #[derive(Debug, Deserialize, Serialize)]
 struct AppConfig {
@@ -21,7 +21,7 @@ struct AppConfig {
     channels: Vec<String>,
 }
 
-async fn read_config() -> AppConfig {
+fn read_config() -> AppConfig {
     if Path::new("config.toml").exists() {
         println!("found configuration file");
         let config_str = fs::read_to_string("config.toml").expect("Unable to read config.toml");
@@ -65,7 +65,6 @@ async fn read_config() -> AppConfig {
 
         let config_str = toml::to_string(&config).expect("Unable to serialize config");
         fs::write("config.toml", config_str).expect("Unable to write config.toml");
-
         config
     }
 }
@@ -74,10 +73,11 @@ enum UserCommand {
     Join(String),
     Msg(String),
     Switch(String),
+    Query(String),
     Unknown,
 }
 
-async fn parse_user_input(line: &str) -> UserCommand {
+fn parse_user_input(line: &str) -> UserCommand {
     let parts: Vec<&str> = line.split_whitespace().collect();
     if parts.is_empty() {
         return UserCommand::Unknown;
@@ -85,6 +85,7 @@ async fn parse_user_input(line: &str) -> UserCommand {
 
     match parts[0] {
         "/join" if parts.len() > 1 => UserCommand::Join(parts[1].to_owned()),
+        "/query" if parts.len() > 1 => UserCommand::Query(parts[1].to_owned()),
         "/msg" if parts.len() > 1 => {
             let message = parts[1..].join(" ");
             UserCommand::Msg(message)
@@ -93,26 +94,20 @@ async fn parse_user_input(line: &str) -> UserCommand {
         _ => UserCommand::Unknown,
     }
 }
-async fn handle_user_input(sender: mpsc::Sender<UserCommand>) {
-    use tokio::io::stdin;
-    use tokio_util::codec::{FramedRead, LinesCodec};
+fn handle_user_input(sender: mpsc::Sender<UserCommand>) {
+loop{
     let stdin = stdin();
-    let mut lines = FramedRead::new(stdin, LinesCodec::new());
-    while let Some(line) = lines.next().await {
-        if let Ok(input) = line {
-            let cmd = parse_user_input(&input).await;
+let mut line = String::new();
+stdin.read_line(&mut line).unwrap();
+            let cmd = parse_user_input(&line);
             println!("{:?}", cmd);
-            if sender.send(cmd).await.is_err() {
-                println!("error sending message");
-                break;
-            }
+line.clear();
+           sender.send(cmd).unwrap();
         }
-    }
 }
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = read_config().await;
+    let config = read_config();
 
     let irc_config = Config {
         nickname: Some(config.nickname),
@@ -126,35 +121,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let mut client = Client::from_config(irc_config).await?;
     client.identify()?;
-
-    let (tx, mut rx) = mpsc::channel::<UserCommand>(32);
+    let (tx, rx) = mpsc::channel::<UserCommand>();
     let joined_channels = Arc::new(Mutex::new(HashSet::new()));
     let current_channel = Arc::new(Mutex::new(String::new()));
     let mut stream = client.stream()?;
     for channel in &config.channels {
-        joined_channels.lock().unwrap().insert(channel.clone());
-        *current_channel.lock().unwrap() = channel.clone();
+joined_channels.lock().unwrap().insert(channel.clone());
+         *current_channel.lock().unwrap() = channel.clone();
         client.send_join(channel)?;
     }
-    let input_processor = tokio::spawn(handle_user_input(tx));
-    while let Some(message) = stream.next().await.transpose()? {
-        print!("{}", message);
-        if let Command::PRIVMSG(ref target, ref msg) = message.command {
-            println!("{}: {}", target, msg);
-        }
-    }
+    let input_processor = tokio::task::spawn_blocking(|| handle_user_input(tx));
 
+let current_channel_clone = current_channel.clone();
+let joined_channels_clone = joined_channels.clone();
     let server_messages_processor = tokio::spawn(async move {
-    while let Some(cmd) = rx.recv().await {
+        while let Ok(cmd) = rx.recv() {
             match cmd {
                 UserCommand::Join(channel) => {
                     println!("joining channel {}", channel);
-                    joined_channels.lock().unwrap().insert(channel.clone());
-                    *current_channel.lock().unwrap() = channel.clone();
+                    joined_channels_clone.lock().unwrap().insert(channel.clone());
+                    *current_channel_clone.lock().unwrap() = channel.clone();
                     client.send_join(&channel).unwrap();
                 }
+
+                UserCommand::Query(person) => {
+                    println!("opening private message with {}", person);
+                    joined_channels_clone.lock().unwrap().insert(person.clone());
+                    *current_channel_clone.lock().unwrap() = person.clone();
+                    client.send_privmsg(&person, "").unwrap();
+                }
+
                 UserCommand::Msg(message) => {
-                    let target = current_channel.lock().unwrap().clone();
+                    let target = current_channel_clone.lock().unwrap().clone();
                     if !target.is_empty() {
                         client.send_privmsg(&target, &message).unwrap();
                     } else {
@@ -162,11 +160,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
                 UserCommand::Switch(channel) => {
-                    if joined_channels.lock().unwrap().contains(&channel) {
-                        *current_channel.lock().unwrap() = channel;
+                    if joined_channels_clone.lock().unwrap().contains(&channel) {
+                        *current_channel_clone.lock().unwrap() = channel;
                     } else {
-                        joined_channels.lock().unwrap().insert(channel.clone());
-                        *current_channel.lock().unwrap() = channel.clone();
+                        joined_channels_clone.lock().unwrap().insert(channel.clone());
+                        *current_channel_clone.lock().unwrap() = channel.clone();
                         client.send_join(&channel).unwrap();
                     }
                 }
@@ -176,6 +174,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     });
-        tokio::join!(input_processor, server_messages_processor)?;
+    while let Some(message) = stream.next().await.transpose()? {
+        println!("{}", message);
+        if let Command::PRIVMSG(ref target, ref msg) = message.command {
+let target = if let Some(query_target) = message.response_target(){
+query_target}
+else{
+&target
+};
+            println!("{}: {}", target, msg);
+        }
+    }
+
+    tokio::try_join!(input_processor, server_messages_processor)?;
     Ok(())
 }


### PR DESCRIPTION
this patchset is supposed to add more conformance to the irc standard by employing a crate dedicated for that. With it, the following features are possible:

* sending more complex irc messages, as well as parsing them, simply with rust types, no manual marshaling involved this time
* support for tls, as well as irc sasl authentication if the server supports it. This is particularly important for next generation irc servers, for example libera.chat, which value security even in an inherently insecure protocol
* the ability of having more structured errors than oops, something just went wrong, <insert tcp bytes here>
* better tokio integration, with usage of asyncronous streams for typed messages

With this patchset, I also included the following new features:

* prejoin channel list: specify the list, either manually in the configuration file, or when you're prompted if you want to let the program generate one for you
* remembering current channel: once you joined a channel, or the last channel in the list, will be remembered by the program as the current channel. Then, if you want to send a message in the current channel, the `/msg <message_text>` is enough
* the ability to switch current channel: if you're in many different channels, you can switch your current channel between them with the switch command, `/switch #<channelname>`. If channel name doesn't exist in the joined channels list, it will be joined on your behalf.